### PR TITLE
:broom: Delete async keyword

### DIFF
--- a/denops/codic/main.ts
+++ b/denops/codic/main.ts
@@ -7,7 +7,7 @@ const config = {
   "filetype": "codic",
 };
 
-export async function main(denops: Denops): Promise<void> {
+export function main(denops: Denops): void {
   denops.dispatcher = {
     async codicVim(args: unknown): Promise<void> {
       ensureString(args);


### PR DESCRIPTION
`async` keyword is not needed because of changed command definition to VimScript.
